### PR TITLE
Expose methods to support motivation + SimpleSlavery

### DIFF
--- a/Source/Need_Motivation.cs
+++ b/Source/Need_Motivation.cs
@@ -21,7 +21,7 @@ namespace PrisonLabor
         private const float JoyRate = 0.006f;
         private const int ReadyToRunLevel = 100;
 
-        private static NeedDef def;
+        private new static NeedDef def;
 
         private int delta;
         private int impatient;
@@ -31,18 +31,18 @@ namespace PrisonLabor
             delta = 0;
             impatient = 0;
             ReadyToRun = false;
-            Insipred = false;
+            Inspired = false;
         }
 
         public bool Enabled { get; set; }
 
-        public bool NeedToBeInspired { get; private set; }
+        public bool NeedToBeInspired { get; set; }
 
         public bool IsLazy { get; private set; }
 
-        public bool ReadyToRun { get; private set; }
+        public bool ReadyToRun { get; set; }
 
-        public bool Insipred { get; private set; }
+        public bool Inspired { get; set; }
 
         public bool CanEscape { get; set; }
 
@@ -95,25 +95,25 @@ namespace PrisonLabor
                                 value -= (int)pawn.needs.food.CurCategory * HungryRate;
                                 value -= (int)pawn.needs.rest.CurCategory * TiredRate;
                                 if (value >= 0)
-                                    Insipred = true;
+                                    Inspired = true;
                                 else
-                                    Insipred = false;
+                                    Inspired = false;
                             }
                             else if (pawn.timetable != null &&
                                      pawn.timetable.CurrentAssignment == TimeAssignmentDefOf.Joy)
                             {
                                 if (value != 0)
-                                    Insipred = true;
+                                    Inspired = true;
                                 else
-                                    Insipred = false;
+                                    Inspired = false;
                                 value += JoyRate;
                             }
                             else
                             {
                                 if (value != 0)
-                                    Insipred = true;
+                                    Inspired = true;
                                 else
-                                    Insipred = false;
+                                    Inspired = false;
                             }
                             delta = value.CompareTo(0.0f);
                             return value;
@@ -121,9 +121,9 @@ namespace PrisonLabor
                         else
                         {
                             if (value != 0)
-                                Insipred = true;
+                                Inspired = true;
                             else
-                                Insipred = false;
+                                Inspired = false;
 
                             delta = value.CompareTo(0.0f);
                             return value;
@@ -198,7 +198,7 @@ namespace PrisonLabor
 
         private void ImpatientTick()
         {
-            if (Insipred || !CanEscape)
+            if (Inspired || !CanEscape)
             {
                 if (impatient != 0)
                 {


### PR DESCRIPTION
Simple Slavery and Prison Labor motivation can work together!  Simple Slavery just needs to be able to affect some properties.  On my local setup, I have Prison Labor's motivation working fine alongside Simple Slavery: slaves from SimpleSlavery can attempt to escape and will not surrender immediately to a PrisonLabor warden/watch prisoner job (they must be arrested and they can/will resist arrest).

This does not work against the dev version, which can't really be supported until it is officially released.

* Added "new" keyword to def field for compliance with C# best-practices.  (Not an issue in dev version, of course.)
* Replaced "Insipred" with "Inspired" and changed to public setter.
* Changed ReadyToRun to public setter.
* Changed NeedToBeInspired to public setter.