### PR TITLE
Fixed issue #151

### DIFF
--- a/Source/Core/GUI_Components/PawnIcons.cs
+++ b/Source/Core/GUI_Components/PawnIcons.cs
@@ -87,7 +87,15 @@ namespace PrisonLabor.Core.GUI_Components
 
         public override void MapComponentTick()
         {
-            worldScale = Screen.height / (2 * Camera.current.orthographicSize);
+            if (Camera.current != null)
+            {
+                worldScale = Screen.height / (2 * Camera.current.orthographicSize);
+            }
+            else
+            {
+                worldScale = Screen.height / 8;
+                Log.ErrorOnce("PrisonLaborError: Camera.current null in MapComponentTick().", typeof(PawnIcons).GetHashCode());
+            }
         }
     }
 }


### PR DESCRIPTION
Modified PawnIcons.MapComponentTick to check if Camera.current is null. Note that the fallback size used is hardcoded at Screen.height / 8.