### PR TITLE
Fixed some ui bug and updated ChineseSimplified translation

### DIFF
--- a/1.5/Defs/MainButton.xml
+++ b/1.5/Defs/MainButton.xml
@@ -52,7 +52,7 @@
     <defName>PL_Assign</defName>
     <workerClass>PawnTable_PlayerPawns</workerClass>
     <columns>
-      <li>Label</li>
+      <li>LabelWithIcon</li>
       <li>MedicalCare</li>
       <li>GapTiny</li>
       <li>Outfit</li>
@@ -68,7 +68,7 @@
     <defName>PL_Overview</defName>
     <workerClass>PawnTable_PlayerPawns</workerClass>
     <columns>
-      <li>Label</li>
+      <li>LabelWithIcon</li>
       <li>GapTiny</li>
       <li>PL_InteractionColumn</li>
       <li>GapTiny</li>
@@ -91,7 +91,7 @@
     <defName>PL_DevTable</defName>
     <workerClass>PawnTable_PlayerPawns</workerClass>
     <columns>
-      <li>Label</li>
+      <li>LabelWithIcon</li>
       <li>GapTiny</li>
       <li>PL_EscapeColumn</li>
       <li>GapTiny</li>

--- a/1.5/Defs/MainButton.xml
+++ b/1.5/Defs/MainButton.xml
@@ -107,6 +107,7 @@
     <headerTip>Interaction mode</headerTip>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_Interaction</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
@@ -114,6 +115,7 @@
     <label>Resocialization</label>
     <headerTip>Prisoner wants to join to your colony</headerTip>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_Resocialization</workerClass>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
@@ -121,6 +123,7 @@
     <label>Has Legcuffs</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_HasLegcuffs</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
@@ -128,12 +131,14 @@
     <label>Has Handcuffs</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_HasHandscuffs</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
     <defName>PL_EscapeColumn</defName>
     <label>Ready to escape</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_EscapeTracker</workerClass>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
@@ -141,6 +146,7 @@
     <label>Motivation</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_Motivation</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
 
   <PawnColumnDef>
@@ -148,6 +154,7 @@
     <label>Treatment</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_Treatment</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
   
   <PawnColumnDef>
@@ -155,12 +162,14 @@
     <label>Has intel</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_HasIntel</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
   <PawnColumnDef>
     <defName>PL_IsWorking</defName>
     <label>Is Working</label>
     <workerClass>PrisonLabor.Core.MainButton_Window.ColumnWorker_IsWorking</workerClass>
     <sortable>true</sortable>
+    <width>70</width>
   </PawnColumnDef>
 
 </Defs>

--- a/Languages/ChineseSimplified/DefInjected/JobDef/JobDef.xml
+++ b/Languages/ChineseSimplified/DefInjected/JobDef/JobDef.xml
@@ -2,6 +2,6 @@
 <LanguageData>
   <PrisonLabor_PrisonerSupervise.reportString>监视囚犯 TargetA.</PrisonLabor_PrisonerSupervise.reportString>
   <PrisonLabor_Arrest.reportString>逮捕 TargetA.</PrisonLabor_Arrest.reportString>
-  <PrisonLabor_HandlePrisonersLegChain.reportString>操作囚犯 TargetA 的腿铐。</PrisonLabor_HandlePrisonersLegChain.reportString>
+  <PrisonLabor_HandlePrisonersLegChain.reportString>操作囚犯 TargetA 的脚铐。</PrisonLabor_HandlePrisonersLegChain.reportString>
   <PrisonLabor_HandlePrisonersHandChain.reportString>操作囚犯 TargetA 的手铐。</PrisonLabor_HandlePrisonersHandChain.reportString>
 </LanguageData>

--- a/Languages/ChineseSimplified/DefInjected/PawnColumnDef/MainButton.xml
+++ b/Languages/ChineseSimplified/DefInjected/PawnColumnDef/MainButton.xml
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-  <PL_InteractionColumn.label>互动</PL_InteractionColumn.label>
-  <PL_InteractionColumn.headerTip>互动模式</PL_InteractionColumn.headerTip>
-  <PL_Resocialization.label>重返社会</PL_Resocialization.label>
-  <PL_Resocialization.headerTip>囚犯想加入你的殖民地</PL_Resocialization.headerTip>
-  <PL_HasLegcuffs.label>有脚铐</PL_HasLegcuffs.label>
-  <PL_HasHandcuffs.label>有手铐</PL_HasHandcuffs.label>
-  <PL_EscapeColumn.label>准备逃跑</PL_EscapeColumn.label>
+  <PL_InteractionColumn.label>互动模式</PL_InteractionColumn.label>
+  <PL_InteractionColumn.headerTip>给囚犯设置互动模式</PL_InteractionColumn.headerTip>
+  <PL_Resocialization.label>可招募</PL_Resocialization.label>
+  <PL_Resocialization.headerTip>当囚犯可招募时，会出现招募按钮，点击后囚犯会直接加入你的殖民地。\n\n译者注: 由事件触发。按钮显示的前提是囚犯是可招募的（抵抗为0），并且囚犯的待遇满意度要>=10%</PL_Resocialization.headerTip>
+  <PL_HasLegcuffs.label>佩戴脚铐</PL_HasLegcuffs.label>
+  <PL_HasHandcuffs.label>佩戴手铐</PL_HasHandcuffs.label>
+  <PL_EscapeColumn.label>逃跑概率</PL_EscapeColumn.label>
   <PL_MotivationColumn.label>积极性</PL_MotivationColumn.label>
+  <PL_TreatmentColumn.label>待遇满意度</PL_TreatmentColumn.label>
+  <PL_HasIntel.label>掌握情报</PL_HasIntel.label>
+  <PL_IsWorking.label>启用劳作</PL_IsWorking.label>
 </LanguageData>

--- a/Languages/ChineseSimplified/DefInjected/PrisonLabor.Core.MainButton_Window.PrisonersTabDef/MainButton.xml
+++ b/Languages/ChineseSimplified/DefInjected/PrisonLabor.Core.MainButton_Window.PrisonersTabDef/MainButton.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   <PL_Overview.label>概述</PL_Overview.label>
   <PL_LaborWindow.label>劳作</PL_LaborWindow.label>
-  <PL_ScheduleWindow.label>时间表</PL_ScheduleWindow.label>
+  <PL_ScheduleWindow.label>管制</PL_ScheduleWindow.label>
   <PL_AssignWindow.label>分配</PL_AssignWindow.label>
-  <PL_DevWindow.label>拓展</PL_DevWindow.label>
+  <PL_DevWindow.label>开发者面板</PL_DevWindow.label>
 </LanguageData>

--- a/Languages/ChineseSimplified/Keyed/Keys.xml
+++ b/Languages/ChineseSimplified/Keyed/Keys.xml
@@ -2,6 +2,8 @@
 <LanguageData>
   <PrisonLabor_PrisonerWork>强迫劳作</PrisonLabor_PrisonerWork>
   <PrisonLabor_WorkAndRecruit>劳作与招募</PrisonLabor_WorkAndRecruit>
+  <PrisonLabor_WorkAndConvert>劳作与转化</PrisonLabor_WorkAndConvert>
+  <PrisonLabor_WorkAndEnslave>劳作与奴役</PrisonLabor_WorkAndEnslave>
   <PrisonLabor_LazyPrisonerMessage>你的囚犯停止劳作了！</PrisonLabor_LazyPrisonerMessage>
   <PrisonLabor_WardenResponseThreshold>监视者报告阙值</PrisonLabor_WardenResponseThreshold>
   <PrisonLabor_StoppingWorkThreshold>停止劳作阙值</PrisonLabor_StoppingWorkThreshold>
@@ -17,7 +19,7 @@
   <PrisonLabor_MotivationMechanics>激励技巧(!)</PrisonLabor_MotivationMechanics>
   <PrisonLabor_MotivationWarning>当选择时，囚犯将需要被激励\n\n警告：需要重新载入存档。</PrisonLabor_MotivationWarning>
   <PrisonLabor_MotivationIcons>灵感/积极图标</PrisonLabor_MotivationIcons>
-  <PrisonLabor_MotivationIconsDesc>When enabled above prisoners head will be displayed blue icon when they are inspired, and green icon when they gain motivation by other factors.</PrisonLabor_MotivationIconsDesc>
+  <PrisonLabor_MotivationIconsDesc>启用后，囚犯头顶将显示图标：蓝色图标表示受到鼓舞，绿色图标表示因其他因素获得激励。</PrisonLabor_MotivationIconsDesc>
   <PrisonLabor_CanGrowAdvanced>囚犯可以种植高级作物</PrisonLabor_CanGrowAdvanced>
   <PrisonLabor_CanGrowAdvancedDesc>当禁用时囚犯只能种不需要技能的植物。</PrisonLabor_CanGrowAdvancedDesc>
   <PrisonLabor_Version>版本: </PrisonLabor_Version>
@@ -38,46 +40,77 @@
   <PrisonLabor_LaborAreaDesc>囚犯劳作区域是只有囚犯才能劳作的区域。殖民者只能在此区域内执行监视劳作。</PrisonLabor_LaborAreaDesc>
   <PrisonLabor_ClearLaborArea>清除劳作区域</PrisonLabor_ClearLaborArea>
   <PrisonLabor_ExpandLaborArea>扩张劳作区域</PrisonLabor_ExpandLaborArea>
+
   <PrisonLabor_EnableRevolts>启用叛乱</PrisonLabor_EnableRevolts>
   <PrisonLabor_EnableRevoltsDesc>启用时，有时会用叛乱事件取代原版的越狱。</PrisonLabor_EnableRevoltsDesc>
   <PrisonLabor_LaborAreaWarning>劳作区不需要囚犯劳作。\n\n该区域禁止殖民者劳作。\n\n这是用于防止你的殖民者在这片区域劳作。囚犯会在他们可以到达的任意区域劳作。</PrisonLabor_LaborAreaWarning>
   <PrisonLabor_DontShowAgain>不再显示</PrisonLabor_DontShowAgain>
   <PrisonLabor_ShowTreatmentHappiness>显示待遇满意度</PrisonLabor_ShowTreatmentHappiness>
   <PrisonLabor_ShowTreatmentHappinessDesc>启用时，待遇满意度会显示在需求页中。</PrisonLabor_ShowTreatmentHappinessDesc>
-  <PrisonLabor_ColonyOnlyShort>只允许殖民地</PrisonLabor_ColonyOnlyShort>
-  <PrisonLabor_ColonistsOnlyShort>只允许殖民地</PrisonLabor_ColonistsOnlyShort>
-  <PrisonLabor_PrisonersOnlyShort>只允许囚犯</PrisonLabor_PrisonersOnlyShort>
-  <PrisonLabor_ColonyOnly>只允许殖民地</PrisonLabor_ColonyOnly>
+
+  <PrisonLabor_ColonyOnlyShort>任何人</PrisonLabor_ColonyOnlyShort>
+  <PrisonLabor_ColonistsOnlyShort>殖民者</PrisonLabor_ColonistsOnlyShort>
+  <PrisonLabor_PrisonersOnlyShort>囚犯</PrisonLabor_PrisonersOnlyShort>
+
+  <PrisonLabor_ColonyOnly>任何人</PrisonLabor_ColonyOnly>
   <PrisonLabor_ColonistsOnly>只允许殖民者</PrisonLabor_ColonistsOnly>
   <PrisonLabor_PrisonersOnly>只允许囚犯</PrisonLabor_PrisonersOnly>
   <PrisonLabor_PrisonersAndSlaveOnly>任何非殖民者</PrisonLabor_PrisonersAndSlaveOnly>
+
+  <!-- 0.10 -->
   <PrisonLabor_RecruitButtonLabel>招募</PrisonLabor_RecruitButtonLabel>
   <PrisonLabor_RecruitButtonDesc>准备加入殖民地</PrisonLabor_RecruitButtonDesc>
+
   <PrisonLabor_Alert_EscapingPrisoners_Title>囚犯可以逃脱</PrisonLabor_Alert_EscapingPrisoners_Title>
   <PrisonLabor_Alert_EscapingPrisoners_DefaultExplanation>囚犯可以到达地图边缘并逃脱。只要殖民者不密切关注，他们就会尝试逃跑。</PrisonLabor_Alert_EscapingPrisoners_DefaultExplanation>
   <PrisonLabor_Alert_EscapingPrisoners_ExplanationFormat>这些囚犯可以逃跑：\n\n{0}\n只要殖民者不密切关注，他们就会尝试逃跑。</PrisonLabor_Alert_EscapingPrisoners_ExplanationFormat>
+
   <PrisonLabor_ButtonRemoveModFromSave>选择存档</PrisonLabor_ButtonRemoveModFromSave>
-  <PrisonLabor_ButtonRemoveModFromSaveDesc>从存档中删除监狱劳力</PrisonLabor_ButtonRemoveModFromSaveDesc>
+  <PrisonLabor_ButtonRemoveModFromSaveDesc>从存档中移除Prison Labor模组</PrisonLabor_ButtonRemoveModFromSaveDesc>
+  
   <PrisonLabor_ButtonBackup>备份</PrisonLabor_ButtonBackup>
   <PrisonLabor_ButtonProceed>继续</PrisonLabor_ButtonProceed>
+  
   <PrisonLabor_UpgradeSaveProcessMessage>更新 [PrisonLabor] 模组</PrisonLabor_UpgradeSaveProcessMessage>
-  <PrisonLabor_UpgradeSaveDialogMessage>你正在从存档中移除监狱劳力模组。在这操作之后，你可以在没有该模组的情况下游玩。</PrisonLabor_UpgradeSaveDialogMessage>
+  <PrisonLabor_UpgradeSaveDialogMessage>你正在从存档中移除Prison Labor模组。在这操作之后，你可以在没有该模组的情况下游玩。</PrisonLabor_UpgradeSaveDialogMessage>
   <PrisonLabor_BackupSaveDialogMessage>请用下面的按钮备份文件</PrisonLabor_BackupSaveDialogMessage>
+
   <PrisonLabor_ReplayTurorialsButton>教程</PrisonLabor_ReplayTurorialsButton>
   <PrisonLabor_ShowTutorialButton>显示</PrisonLabor_ShowTutorialButton>
+
   <PrisonLabor_CommandBedSetOwnerLabel>分配囚犯</PrisonLabor_CommandBedSetOwnerLabel>
   <PrisonLabor_CommandBedSetOwnerDesc>把这张床分配给特定的囚犯使用</PrisonLabor_CommandBedSetOwnerDesc>
+
   <PrisonLabor_EnableSuicide>囚犯可以自杀</PrisonLabor_EnableSuicide>
   <PrisonLabor_EnableSuicideDesc>可以让囚犯在不开心的时候自杀</PrisonLabor_EnableSuicideDesc>
+
   <PrisonLabor_EnableFullHealRest>使囚犯得到充分的治疗休息</PrisonLabor_EnableFullHealRest>
   <PrisonLabor_EnableFullHealRestDesc>囚犯会一直卧床直到完全痊愈</PrisonLabor_EnableFullHealRestDesc>
+
   <PrisonLabor_HandcuffsPut>戴上手铐</PrisonLabor_HandcuffsPut>
   <PrisonLabor_HandcuffsRemove>摘除手铐</PrisonLabor_HandcuffsRemove>
   <PrisonLabor_LegcuffsPut>戴上脚铐</PrisonLabor_LegcuffsPut>
   <PrisonLabor_LegcuffsRemove>摘除脚铐</PrisonLabor_LegcuffsRemove>
+  
   <PrisonLabor_ToggleHandscuffs>摘除/戴上手铐</PrisonLabor_ToggleHandscuffs>
   <PrisonLabor_ToggleLegscuffs>摘除/戴上脚铐</PrisonLabor_ToggleLegscuffs>
+
   <PrisonLabor_EnableDebugLogs>启用调试日志</PrisonLabor_EnableDebugLogs>
   <PrisonLabor_EnableDebugLogsDesc>打开此选项可能会发送垃圾日志</PrisonLabor_EnableDebugLogsDesc>
-  <PrisonLabor_WorkAndConvert>劳作与转化</PrisonLabor_WorkAndConvert>
+
+  <PrisonLabor_CannotTakeToBed>无法带去床上</PrisonLabor_CannotTakeToBed>
+  <PrisonLabor_TakingToBed>将 {0} 带去床上</PrisonLabor_TakingToBed>
+
+  <PrisonLabor_MustBePrisoner>{0} 必须是非玩家派系的囚犯。</PrisonLabor_MustBePrisoner>
+  <PrisonLabor_NoIntel>{0} 没有更多情报了。</PrisonLabor_NoIntel>
+  <PrisonLabor_TooSoonInterrogation>{0} 需要在下次审讯前休息一段时间。</PrisonLabor_TooSoonInterrogation>
+  <PrisonLabor_MissingComp>出现错误，该角色缺少重要组件。</PrisonLabor_MissingComp>
+
+  <PrisonLabor_Prisoner>囚犯 {0}</PrisonLabor_Prisoner>
+
+  <PrisonLabor_MechWorksInLaborArea>机械体可以在囚犯劳作区域工作</PrisonLabor_MechWorksInLaborArea>
+  <PrisonLabor_MechWorksInLaborAreaDesc>禁用后机械体将不会在囚犯劳作区域工作</PrisonLabor_MechWorksInLaborAreaDesc>
+
+  <PrisonLabor_EnableWorkByDefault>默认启用“强迫劳作”：</PrisonLabor_EnableWorkByDefault>
+  <PrisonLabor_EnableWorkByDefaultDesc>启用后，所有新囚犯将默认启用“强迫劳作”互动模式</PrisonLabor_EnableWorkByDefaultDesc>
 </LanguageData>

--- a/Source/Core/MainButton_Window/ColumnWorker_EscapeTracker.cs
+++ b/Source/Core/MainButton_Window/ColumnWorker_EscapeTracker.cs
@@ -6,12 +6,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 using Verse;
 
 namespace PrisonLabor.Core.MainButton_Window
 {
     public class ColumnWorker_EscapeTracker : PawnColumnWorker_Text
     {
+        protected override TextAnchor Anchor => TextAnchor.MiddleCenter;
+
         protected override string GetTextFor(Pawn pawn)
         {
             var prisonerComp = pawn.TryGetComp<PrisonerComp>();

--- a/Source/Core/MainButton_Window/ColumnWorker_Motivation.cs
+++ b/Source/Core/MainButton_Window/ColumnWorker_Motivation.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 using Verse;
 
 namespace PrisonLabor.Core.MainButton_Window
 {
     public class ColumnWorker_Motivation : PawnColumnWorker_Text
     {
+        protected override TextAnchor Anchor => TextAnchor.MiddleCenter;
+
         protected override string GetTextFor(Pawn pawn)
         {
             Need_Motivation motivation = pawn.needs.TryGetNeed<Need_Motivation>();

--- a/Source/Core/MainButton_Window/ColumnWorker_Treatment.cs
+++ b/Source/Core/MainButton_Window/ColumnWorker_Treatment.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 using Verse;
 
 namespace PrisonLabor.Core.MainButton_Window
 {
     public class ColumnWorker_Treatment : PawnColumnWorker_Text
     {
+        protected override TextAnchor Anchor => TextAnchor.MiddleCenter;
+
         protected override string GetTextFor(Pawn pawn)
         {
             Need_Treatment treatmeant = pawn.needs.TryGetNeed<Need_Treatment>();

--- a/Source/Core/MainButton_Window/CustomTabWindow.cs
+++ b/Source/Core/MainButton_Window/CustomTabWindow.cs
@@ -9,112 +9,13 @@ using Verse;
 
 namespace PrisonLabor.Core.MainButton_Window
 {
-  public abstract class CustomTabWindow : Window
+  public abstract class CustomTabWindow : MainTabWindow_PawnTable
   {
-    private PawnTable table;
+    protected override IEnumerable<Pawn> Pawns => Find.CurrentMap.mapPawns.PrisonersOfColony;
 
-    protected virtual float ExtraBottomSpace => 53f;
-
-    protected virtual float ExtraTopSpace => 0f;
-
-    protected abstract PawnTableDef PawnTableDef
+    protected CustomTabWindow()
     {
-      get;
+      def = MainButtonDefOf.PL_Prisoners_Menu;
     }
-
-    protected override float Margin => 6f;
-
-    public virtual Vector2 RequestedTabSize
-    {
-      get
-      {
-        if (table == null)
-        {
-          return Vector2.zero;
-        }
-        return new Vector2(table.Size.x + Margin * 2f, table.Size.y + ExtraTopSpace + ExtraBottomSpace + Margin * 2f);
-      }
-    }
-
-    public virtual MainTabWindowAnchor Anchor => MainTabWindowAnchor.Left;
-
-    public override Vector2 InitialSize
-    {
-      get
-      {
-        Vector2 requestedTabSize = RequestedTabSize;
-        if (requestedTabSize.y > (float)(UI.screenHeight - 35))
-        {
-          requestedTabSize.y = UI.screenHeight - 35;
-        }
-        if (requestedTabSize.x > (float)UI.screenWidth)
-        {
-          requestedTabSize.x = UI.screenWidth;
-        }
-        return requestedTabSize;
-      }
-    }
-    protected virtual IEnumerable<Pawn> Pawns => Find.CurrentMap.mapPawns.FreeColonists;
-
-    public override void PostOpen()
-    {
-      base.PostOpen();
-      if (table == null)
-      {
-        table = CreateTable();
-      }
-      SetDirty();
-    }
-
-    public override void DoWindowContents(Rect rect)
-    {
-      table.PawnTableOnGUI(new Vector2(rect.x, rect.y + ExtraTopSpace));
-    }
-
-    public void Notify_PawnsChanged()
-    {
-      SetDirty();
-    }
-
-    public override void Notify_ResolutionChanged()
-    {
-      table = CreateTable();
-      base.Notify_ResolutionChanged();
-    }
-
-    private PawnTable CreateTable()
-    {
-      return (PawnTable)Activator.CreateInstance(PawnTableDef.workerClass, PawnTableDef, (Func<IEnumerable<Pawn>>)(() => Pawns), UI.screenWidth - (int)(Margin * 2f), (int)((float)(UI.screenHeight - 35) - ExtraBottomSpace * 1.5f - ExtraTopSpace - Margin * 2f));
-    }
-
-    protected void SetDirty()
-    {
-      table.SetDirty();
-      SetInitialSizeAndPosition();
-    }
-    public CustomTabWindow()
-    {
-      layer = WindowLayer.GameUI;
-      soundAppear = null;
-      soundClose = SoundDefOf.TabClose;
-      doCloseButton = false;
-      doCloseX = false;
-      preventCameraMotion = false;
-    }
-
-    protected override void SetInitialSizeAndPosition()
-    {
-      base.SetInitialSizeAndPosition();
-      if (Anchor == MainTabWindowAnchor.Left)
-      {
-        windowRect.x = 0f;
-      }
-      else
-      {
-        windowRect.x = (float)UI.screenWidth - windowRect.width;
-      }
-      windowRect.y = (float)(UI.screenHeight - 35) - windowRect.height;
-    }
-
   }
 }

--- a/Source/Core/MainButton_Window/CustomTabWindow.cs
+++ b/Source/Core/MainButton_Window/CustomTabWindow.cs
@@ -15,7 +15,7 @@ namespace PrisonLabor.Core.MainButton_Window
 
     protected CustomTabWindow()
     {
-      def = MainButtonDefOf.PL_Prisoners_Menu;
+      def = UIDefsOf.PL_Prisoners_Menu;
     }
   }
 }

--- a/Source/Core/MainButton_Window/MainTabWindow_Assign.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Assign.cs
@@ -12,8 +12,5 @@ namespace PrisonLabor.Core.MainButton_Window
     {
         protected override PawnTableDef PawnTableDef => UIDefsOf.PL_Assign;
 
-        protected override IEnumerable<Pawn> Pawns => Find.CurrentMap.mapPawns.PrisonersOfColony;
-
-
     }
 }

--- a/Source/Core/MainButton_Window/MainTabWindow_Dev.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Dev.cs
@@ -12,8 +12,6 @@ namespace PrisonLabor.Core.MainButton_Window
     {
         protected override PawnTableDef PawnTableDef => UIDefsOf.PL_DevTable;
 
-        protected override IEnumerable<Pawn> Pawns => Find.CurrentMap.mapPawns.PrisonersOfColony;
-
 
     }
 }

--- a/Source/Core/MainButton_Window/MainTabWindow_Labor.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Labor.cs
@@ -23,7 +23,7 @@ namespace PrisonLabor.Core.MainButton_Window
     {
       get
       {
-        foreach (var pawn in Find.CurrentMap.mapPawns.PrisonersOfColony)
+        foreach (var pawn in base.Pawns)
         {
           if (PrisonLaborUtility.LaborEnabled(pawn))
           {
@@ -71,16 +71,12 @@ namespace PrisonLabor.Core.MainButton_Window
       }
       if (Current.Game.playSettings.useWorkPriorities)
       {
-        GUI.color = new Color(1f, 1f, 1f, 0.5f);
-        Text.Font = GameFont.Tiny;
-        Widgets.Label(new Rect(rect.x, rect.y + rect.height + 4f, rect.width, 60f), "PriorityOneDoneFirst".Translate());
-        Text.Font = GameFont.Small;
-        GUI.color = Color.white;
+        using (new TextBlock(new Color(1f, 1f, 1f, 0.5f)))
+          Widgets.Label(new Rect(rect.x, rect.yMax - 6f, rect.width, 60f), "PriorityOneDoneFirst".Translate());
       }
-      if (!Current.Game.playSettings.useWorkPriorities)
-      {
-        UIHighlighter.HighlightOpportunity(rect, "ManualPriorities-Off");
-      }
+      if (Current.Game.playSettings.useWorkPriorities)
+        return;
+      UIHighlighter.HighlightOpportunity(rect, "ManualPriorities-Off");
     }
     public override void PostOpen()
     {

--- a/Source/Core/MainButton_Window/MainTabWindow_Labor.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Labor.cs
@@ -72,10 +72,14 @@ namespace PrisonLabor.Core.MainButton_Window
       if (Current.Game.playSettings.useWorkPriorities)
       {
         using (new TextBlock(new Color(1f, 1f, 1f, 0.5f)))
+        {
           Widgets.Label(new Rect(rect.x, rect.yMax - 6f, rect.width, 60f), "PriorityOneDoneFirst".Translate());
+        }
       }
       if (Current.Game.playSettings.useWorkPriorities)
+      {
         return;
+      }
       UIHighlighter.HighlightOpportunity(rect, "ManualPriorities-Off");
     }
     public override void PostOpen()

--- a/Source/Core/MainButton_Window/MainTabWindow_Overview.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Overview.cs
@@ -12,8 +12,5 @@ namespace PrisonLabor.Core.MainButton_Window
     {
         protected override PawnTableDef PawnTableDef => UIDefsOf.PL_Overview;
 
-        protected override IEnumerable<Pawn> Pawns => Find.CurrentMap.mapPawns.PrisonersOfColony;
-
-
     }
 }

--- a/Source/Core/MainButton_Window/MainTabWindow_Schedule.cs
+++ b/Source/Core/MainButton_Window/MainTabWindow_Schedule.cs
@@ -22,7 +22,7 @@ namespace PrisonLabor.Core.MainButton_Window
 		{
 			get
 			{
-				foreach (var pawn in Find.CurrentMap.mapPawns.PrisonersOfColony)
+				foreach (var pawn in base.Pawns)
 				{
 					if (PrisonLaborUtility.LaborEnabled(pawn))
 					{

--- a/Source/Core/MainButton_Window/PrisonerButtonWindow.cs
+++ b/Source/Core/MainButton_Window/PrisonerButtonWindow.cs
@@ -31,7 +31,7 @@ namespace PrisonLabor.Core.MainButton_Window
             get
             {
                 var size = new Vector2(1230f, 155f);
-                foreach(var tab in tabsView.Where(kv => !kv.Key.dev || kv.Key.dev == Prefs.DevMode).Select(kv => kv.Value))
+                foreach(var tab in tabsView.Where(kv => ShouldShowTab(kv.Key)).Select(kv => kv.Value))
                 {                    
                     size.x = Math.Max(size.x, tab.RequestedTabSize.x);
                     size.y = Math.Max(size.y, tab.RequestedTabSize.y);
@@ -105,7 +105,7 @@ namespace PrisonLabor.Core.MainButton_Window
         {
             base.PostOpen();
             tabs.Clear();
-            foreach (var tabDef in tabsView.Keys.Where(d => !d.dev || d.dev == Prefs.DevMode).OrderBy(d => d.order))
+            foreach (var tabDef in tabsView.Keys.Where(ShouldShowTab).OrderBy(d => d.order))
             {                
                 tabs.Add(new PrisonerWindowTab(tabDef, tabDef.LabelCap, delegate
                 {
@@ -119,6 +119,11 @@ namespace PrisonLabor.Core.MainButton_Window
                 CurTab = tabs[1].def;
             }
             GetTable(CurTab).PostOpen();
+        }
+
+        private bool ShouldShowTab(PrisonersTabDef tabDef)
+        {
+            return !tabDef.dev || tabDef.dev == Prefs.DevMode;
         }
 
         private CustomTabWindow GetTable(PrisonersTabDef tabDef)

--- a/Source/Core/MainButton_Window/UIDefsOf.cs
+++ b/Source/Core/MainButton_Window/UIDefsOf.cs
@@ -18,4 +18,9 @@ namespace PrisonLabor.Core.MainButton_Window
             DefOfHelper.EnsureInitializedInCtor(typeof(UIDefsOf));
         }
     }
+
+    [DefOf]
+    public static class MainButtonDefOf {
+        public static MainButtonDef PL_Prisoners_Menu;
+    }
 }

--- a/Source/Core/MainButton_Window/UIDefsOf.cs
+++ b/Source/Core/MainButton_Window/UIDefsOf.cs
@@ -13,14 +13,12 @@ namespace PrisonLabor.Core.MainButton_Window
         public static PawnTableDef PL_Assign;
         public static PawnTableDef PL_Overview;
         public static PawnTableDef PL_DevTable;
+
+        public static MainButtonDef PL_Prisoners_Menu;
+
         static UIDefsOf()
         {
             DefOfHelper.EnsureInitializedInCtor(typeof(UIDefsOf));
         }
-    }
-
-    [DefOf]
-    public static class MainButtonDefOf {
-        public static MainButtonDef PL_Prisoners_Menu;
     }
 }


### PR DESCRIPTION
## 📌 Pull Request Description

This PR fixes several UI refresh and window initialization issues, and includes structural improvements to enhance maintainability and consistency.

---

### 🐞 Bug Fixes

- Fixed an issue where toggling `IsWorking` in the `PL_Overview` tab did not trigger a refresh in `PL_LaborWindow`. Previously, users had to close and reopen the window manually.
- Fixed a bug where the first click on `PL_Prisoners_Menu` after game startup resulted in a malformed window, appearing as a narrow strip in the bottom-left corner.
- Fixed incorrect invocation timing of `PostOpen()` in multiple tab windows, which caused initialization logic to fail.

---

### 🛠️ Refactoring & Improvements

- Renamed local `def` variables that conflicted with inherited `def` fields to improve clarity and prevent unintended behavior.
- Refactored `CustomTabWindow` to directly inherit from `MainTabWindow_PawnTable`, reducing redundant code and improving consistency across tab windows.

---

### 📎 Additional Notes

These changes improve the reliability of UI behavior and provide a cleaner foundation for future feature development.
