### PR TITLE
Fix dictionary population to handle mismatched key and value counts

### DIFF
--- a/Source/Core/Other/ScribeUtils.cs
+++ b/Source/Core/Other/ScribeUtils.cs
@@ -26,7 +26,8 @@ namespace PrisonLabor.Core.Other
             if (Verse.Scribe.mode == LoadSaveMode.PostLoadInit)
             {
                 dict = new Dictionary<T, S>();
-                for (var i = 0; i < tmpKeys.Count; i++)
+                int count = Math.Min(tmpKeys.Count, tmpVals.Count);
+                for (var i = 0; i < count; i++)
                     if (tmpKeys[i] != null && tmpVals[i] != null)
                         dict[tmpKeys[i]] = tmpVals[i];
             }


### PR DESCRIPTION

I'm encountering an error when loading saved games with the PrisonLabor mod. The error occurs during `PostLoadInit `in `PrisonLabor.Core.Trackers.CuffsTracker`, throwing an `ArgumentOutOfRangeException `when accessing an out-of-range index in a list.

Error Log:
```
Could not do PostLoadInit on PrisonLabor.Core.Trackers.CuffsTracker: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
[Ref 2BA144C9]
 [0x0000c] in <51fded79cd284d4d911c5949aff4cb21>:0 
  at System.Collections.Generic.List`1[T].get_Item (System.Int32 index) [0x00009] in <51fded79cd284d4d911c5949aff4cb21>:0 
  at PrisonLabor.Core.Other.ScribeUtils`2[T,S].Scribe (System.Collections.Generic.Dictionary`2[T,S]& dict, System.String name) [0x00098] in <41106d99db6e477e9c5ba392889be547>:0 
  at PrisonLabor.Core.Trackers.CuffsTracker.ExposeData () [0x00001] in <41106d99db6e477e9c5ba392889be547>:0 
  at Verse.PostLoadIniter.DoAllPostLoadInits () [0x00032] in <46372f5dadbf4af8939e608076251180>:0
```
Suggested Solution:

The error appears to originate in `ScribeUtils.Scribe` when trying to access an invalid index in a list during serialization. I've added bounds checking before accessing the list to prevent the exception. This fix prevents the crash and allows the game to continue loading.

I haven't included warning logging in this fix, but if you think it would be helpful for debugging cases where data might be corrupted or incomplete, a warning could be added.

This is my first contribution to a mod, so I'm open to feedback if this approach isn't helpful or could be improved. I'm here to learn and help make the mod better.